### PR TITLE
Allow bucket names to contain periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ How many concurrent connections to keep open while uploading to S3. Defaults to 
 #### options.allow_dot_notation
 Type: `Boolean`
 
-Skip the Amazon security feature that prevents you from connecting to any bucket with a period (.) in its name. Must be set to `true` if you bucket name contains a period. Defaults to **false**.
+Skip the Amazon security feature that prevents you from connecting to any bucket with a period (.) in its name. Must be set to `true` if your bucket name contains a period. Defaults to **false**.
 
 #### Note
 The project is based on [awssum](http://awssum.io), and uses code from a [gist](https://gist.github.com/chilts/3687910) by @chilts and @twhid.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Type: `Integer`
 
 How many concurrent connections to keep open while uploading to S3. Defaults to **3**.
 
+#### options.allow_dot_notation
+Type: `Boolean`
+
+Skip the Amazon security feature that prevents you from connecting to any bucket with a period (.) in its name. Must be set to `true` if you bucket name contains a period. Defaults to **false**.
+
 #### Note
 The project is based on [awssum](http://awssum.io), and uses code from a [gist](https://gist.github.com/chilts/3687910) by @chilts and @twhid.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-awssum-deploy",
   "description": "Deploy your static files to S3",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/dustMason/grunt-awssum-deploy",
   "author": {
     "name": "Jordan Sitkin",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "awssum": "1.0",
     "awssum-amazon-s3": "1.0",
-    "async": "> 0.1.0"
+    "async": "> 0.1.0",
+    "mime": "~1.2.11"
   },
   "devDependencies": {},
   "peerDependencies": {

--- a/tasks/awssum-deploy.js
+++ b/tasks/awssum-deploy.js
@@ -32,6 +32,14 @@ module.exports = function(grunt) {
     if (options.connections) { connections = options.connections; } else { connections = 3; }
     delete options.connections;
 
+    /**
+     * Setting process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0 will allow you
+     * to upload to an S3 bucket with a period (.) in it's name by skipping
+     * an Amazon security option that is enabled by default.
+     */
+    if (options.allow_dot_notation == true) { process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0 }
+    delete options.allow_dot_notation;
+
     var defaults = {
       BucketName: options.bucket,
       Acl: 'public-read'


### PR DESCRIPTION
When hosting a static site in an S3 bucket, it is common to include periods in the bucket name. Currently, there is an Amazon security feature that is throwing an error when you try to deploy to a bucket using "dot notation" in the name, which can be manually turned off.

This PR adds the following:
- An option called “allow_dot_notation”, which must be set to true if your bucket name contains a period.
- "mime": "~1.2.11" as a dependency, which is required for the task to run, but was previously not saved to package.json
